### PR TITLE
Remove obsolete unused floating wrappers and cleaners.

### DIFF
--- a/src/app/widgets/recaptcha_widget.php
+++ b/src/app/widgets/recaptcha_widget.php
@@ -5,10 +5,7 @@ class RecaptchaWidget extends Widget{
 		$lang = $ATK14_GLOBAL->getLang(); // TODO: https://developers.google.com/recaptcha/docs/language
 		$out = array();
 		$out[] = '<script src="https://www.google.com/recaptcha/api.js?hl='.$lang.'"></script>'; // TODO: Paste this snippet before the closing </head> tag on your HTML template:
-		$out[] = '<div style="float: left; min-height: 80px;">'; // TODO: Do I like the inline style?
 		$out[] = '<div class="g-recaptcha" data-sitekey="'.RECAPTCHA_SITE_KEY.'"></div>';
-		$out[] = '</div>';
-		$out[] = '<div style="clear: both;"></div>';
 
 		// This is a fake hidden field which makes the Form framework in thinking that the value is submitted as usually.
 		// It is important for the Field::clean() method.


### PR DESCRIPTION
That inline styled floating wrappers are breaking common flow of form field. They are not easily overridden. I do not understand they purpose. Please @yarri , consider removing them.